### PR TITLE
`<bitset>` implementation of board

### DIFF
--- a/include/board.h
+++ b/include/board.h
@@ -6,11 +6,11 @@
 #ifndef BOARD_H_INCLUDED
 #define BOARD_H_INCLUDED
 
+typedef std::bitset<9> BoardLayer;
 class Board
 {
 
 public:
-    typedef std::bitset<9> BoardLayer;
     BoardLayer x_layer;
     BoardLayer o_layer;
 

--- a/include/board.h
+++ b/include/board.h
@@ -1,6 +1,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
+#include <bitset>
 
 #ifndef BOARD_H_INCLUDED
 #define BOARD_H_INCLUDED
@@ -9,12 +10,14 @@ class Board
 {
 
 public:
-    int x_layer = 0b000000000;
-    int o_layer = 0b000000000;
+    typedef std::bitset<9> BoardLayer;
+    BoardLayer x_layer;
+    BoardLayer o_layer;
 
     char is_ended();
     void printBoard();
     void clearCell(int index);
+    BoardLayer getSquashedBoard();
     std::vector<int> getFreeCells();
     void setCell(char layer, int index);
 };

--- a/include/board.h
+++ b/include/board.h
@@ -7,19 +7,19 @@
 #define BOARD_H_INCLUDED
 
 typedef std::bitset<9> BoardLayer;
+
 class Board
 {
-
 public:
     BoardLayer x_layer;
     BoardLayer o_layer;
 
     char is_ended();
-    void printBoard();
-    void clearCell(int index);
-    BoardLayer getSquashedBoard();
-    std::vector<int> getFreeCells();
-    void setCell(char layer, int index);
+    void print_board();
+    void clear_cell(int index);
+    BoardLayer get_squashed_board();
+    std::vector<int> get_free_cells();
+    void set_cell(char layer, int index);
 };
 
 #endif // BOARD_H_INCLUDED

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -7,7 +7,7 @@
 
 void RandomAI::move(Board& board, char mark)
 {
-    board.setCell(mark, board.getFreeCells()[0]);
+    board.set_cell(mark, board.get_free_cells()[0]);
 }
 
 void OptimalAI::move(Board& board, char mark)
@@ -15,13 +15,13 @@ void OptimalAI::move(Board& board, char mark)
     int best_score = -999999;
     int best_index = 0;
 
-    std::vector<int> free_cells = board.getFreeCells();
+    std::vector<int> free_cells = board.get_free_cells();
 
     for(const auto& value: free_cells) {
 
-        board.setCell(mark, value);
+        board.set_cell(mark, value);
         float score = OptimalAI::minimax(board, false, mark);
-        board.clearCell(value);
+        board.clear_cell(value);
 
         if (score > best_score)
         {
@@ -29,7 +29,7 @@ void OptimalAI::move(Board& board, char mark)
             best_index = value;
         }
     }
-    board.setCell(mark, best_index);
+    board.set_cell(mark, best_index);
 }
 
 float OptimalAI::minimax(Board& board, bool maximising, char ai_mark)
@@ -48,11 +48,11 @@ float OptimalAI::minimax(Board& board, bool maximising, char ai_mark)
 
     char opp_mark = ai_mark == 'X' ? 'O' : 'X';
 
-    for (const auto& index: board.getFreeCells())
+    for (const auto& index: board.get_free_cells())
     {
-        board.setCell(maximising ? ai_mark : opp_mark, index);
+        board.set_cell(maximising ? ai_mark : opp_mark, index);
         float score = OptimalAI::minimax(board, !maximising, ai_mark);
-        board.clearCell(index);
+        board.clear_cell(index);
 
         if ((maximising && score > final_score) || (!maximising && score < final_score))
         {

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1,14 +1,13 @@
 #include <string>
 #include <iostream>
 #include <vector>
-
 #include <bitset>
 
 #include "board.h"
 
 char Board::is_ended()
 {
-    BoardLayer win_masks[8] = {
+    int win_masks[8] = {
         0b111000000, 0b000111000, 0b000000111,
         0b100100100, 0b010010010, 0b001001001,
         0b100010001, 0b001010100
@@ -27,7 +26,7 @@ char Board::is_ended()
 
     BoardLayer squashed_board = this->getSquashedBoard();
 
-    if (squashed_board == 0b111111111)
+    if (squashed_board.all())
     {
         return 'D';
     }
@@ -43,12 +42,11 @@ void Board::printBoard()
 
     for (int i = 0; i < 9; i++)
     {
-        int cell_mask = 0b100000000 >> i;
         bool symbol_exists = false;
 
         for (BoardLayer layer: {x_layer, o_layer})
         {
-            if (layer.to_ulong() & cell_mask)
+            if (layer[i])
             {
                 boardArray[i] = (layer == x_layer) ? 'X' : 'O';
                 symbol_exists = true;
@@ -77,16 +75,14 @@ void Board::printBoard()
 
 void Board::clearCell(int index)
 {
-    int cellMask = ~(0b100000000 >> index);
-
-    this->x_layer &= cellMask;
-    this->o_layer &= cellMask;
+    this->x_layer.reset(index);
+    this->o_layer.reset(index);
 }
 
 std::vector<int> Board::getFreeCells()
 {
     std::vector<int> free_cells;
-    BoardLayer squashed_board = this->getSquashedBoard;
+    BoardLayer squashed_board = this->getSquashedBoard();
 
     for (int i = 0; i < 9; i++)
     {
@@ -103,7 +99,10 @@ void Board::setCell(char layer, int index)
 {
     BoardLayer& wanted_layer = layer == 'X' ? this->x_layer : this->o_layer;
 
-    int cellMask = 0b100000000 >> index;
+    wanted_layer.set(index, true);
+};
 
-    wanted_layer |= cellMask;
+BoardLayer Board::getSquashedBoard()
+{
+    return this->x_layer | this->o_layer;
 }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -24,7 +24,7 @@ char Board::is_ended()
         }
     }
 
-    BoardLayer squashed_board = this->getSquashedBoard();
+    BoardLayer squashed_board = this->get_squashed_board();
 
     if (squashed_board.all())
     {
@@ -34,9 +34,9 @@ char Board::is_ended()
     return 'N';
 };
 
-void Board::printBoard()
+void Board::print_board()
 {
-    std::string horizontalSep = "+---+---+---+";
+    std::string horizontal_sep = "+---+---+---+";
 
     char boardArray[9];
 
@@ -60,7 +60,7 @@ void Board::printBoard()
         }
     }
 
-    std::cout << horizontalSep << std::endl;
+    std::cout << horizontal_sep << std::endl;
     for (int i = 0; i < 9; i += 3)
     {
         std::cout <<
@@ -69,20 +69,20 @@ void Board::printBoard()
         " | " << boardArray[i + 2] <<
         " |"  << std::endl;
 
-        std::cout << horizontalSep << std::endl;
+        std::cout << horizontal_sep << std::endl;
     }
 };
 
-void Board::clearCell(int index)
+void Board::clear_cell(int index)
 {
     this->x_layer.reset(index);
     this->o_layer.reset(index);
 }
 
-std::vector<int> Board::getFreeCells()
+std::vector<int> Board::get_free_cells()
 {
     std::vector<int> free_cells;
-    BoardLayer squashed_board = this->getSquashedBoard();
+    BoardLayer squashed_board = this->get_squashed_board();
 
     for (int i = 0; i < 9; i++)
     {
@@ -95,14 +95,14 @@ std::vector<int> Board::getFreeCells()
     return free_cells;
 };
 
-void Board::setCell(char layer, int index)
+void Board::set_cell(char layer, int index)
 {
     BoardLayer& wanted_layer = layer == 'X' ? this->x_layer : this->o_layer;
 
     wanted_layer.set(index, true);
 };
 
-BoardLayer Board::getSquashedBoard()
+BoardLayer Board::get_squashed_board()
 {
     return this->x_layer | this->o_layer;
 }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -85,19 +85,18 @@ void Board::clearCell(int index)
 
 std::vector<int> Board::getFreeCells()
 {
-    std::vector<int> freeCells;
-    BoardLayer cellMask = 0b100000000;
+    std::vector<int> free_cells;
     BoardLayer squashed_board = this->getSquashedBoard;
 
     for (int i = 0; i < 9; i++)
     {
-        if (!(squashed_board & (cellMask >> i)))
+        if (!squashed_board[i])
         {
-            freeCells.push_back(i);
+            free_cells.push_back(i);
         }
     }
 
-    return freeCells;
+    return free_cells;
 };
 
 void Board::setCell(char layer, int index)

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2,28 +2,30 @@
 #include <iostream>
 #include <vector>
 
+#include <bitset>
+
 #include "board.h"
 
 char Board::is_ended()
 {
-    int win_masks[8] = {
+    BoardLayer win_masks[8] = {
         0b111000000, 0b000111000, 0b000000111,
         0b100100100, 0b010010010, 0b001001001,
         0b100010001, 0b001010100
     };
 
-    int squashed_board = this->x_layer | this->o_layer;
-
-    for (int layer : {x_layer, o_layer})
+    for (BoardLayer layer : {x_layer, o_layer})
     {
         for (int mask : win_masks)
         {
-            if ((layer & mask) == mask)
+            if ((layer.to_ulong() & mask) == mask)
             {
                 return (layer == this->x_layer) ? 'X' : 'O';
             }
         }
     }
+
+    BoardLayer squashed_board = this->getSquashedBoard();
 
     if (squashed_board == 0b111111111)
     {
@@ -38,16 +40,15 @@ void Board::printBoard()
     std::string horizontalSep = "+---+---+---+";
 
     char boardArray[9];
-    int squashed_board = this->x_layer | this-> o_layer;
 
     for (int i = 0; i < 9; i++)
     {
         int cell_mask = 0b100000000 >> i;
         bool symbol_exists = false;
 
-        for (int layer: {x_layer, o_layer})
+        for (BoardLayer layer: {x_layer, o_layer})
         {
-            if (layer & cell_mask)
+            if (layer.to_ulong() & cell_mask)
             {
                 boardArray[i] = (layer == x_layer) ? 'X' : 'O';
                 symbol_exists = true;
@@ -70,7 +71,6 @@ void Board::printBoard()
         " | " << boardArray[i + 2] <<
         " |"  << std::endl;
 
-
         std::cout << horizontalSep << std::endl;
     }
 };
@@ -86,8 +86,8 @@ void Board::clearCell(int index)
 std::vector<int> Board::getFreeCells()
 {
     std::vector<int> freeCells;
-    int cellMask = 0b100000000;
-    int squashed_board = this->x_layer | this-> o_layer;
+    BoardLayer cellMask = 0b100000000;
+    BoardLayer squashed_board = this->getSquashedBoard;
 
     for (int i = 0; i < 9; i++)
     {
@@ -102,7 +102,7 @@ std::vector<int> Board::getFreeCells()
 
 void Board::setCell(char layer, int index)
 {
-    int& wanted_layer = layer == 'X' ? this->x_layer : this->o_layer;
+    BoardLayer& wanted_layer = layer == 'X' ? this->x_layer : this->o_layer;
 
     int cellMask = 0b100000000 >> index;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@ void process_user_move(Board& board, char user_mark)
 
 int main()
 {
-
     const char user_mark = 'X';
     const char comp_mark = 'O';
     Board b1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,11 +14,11 @@ void process_user_move(Board& board, char user_mark)
         std::cout << "Enter a move >> ";
         std::cin >> choice;
 
-        std::vector<int> free_cells = board.getFreeCells();
+        std::vector<int> free_cells = board.get_free_cells();
 
         if (std::find(free_cells.begin(), free_cells.end(), choice - 1) != free_cells.end())
         {
-            board.setCell(user_mark, choice - 1);
+            board.set_cell(user_mark, choice - 1);
             return;
         }
     }
@@ -33,13 +33,13 @@ int main()
 
     while (b1.is_ended() == 'N')
     {
-        b1.printBoard();
+        b1.print_board();
         process_user_move(b1, 'X');
         OptimalAI::move(b1, 'O');
         if (b1.is_ended() != 'N'){break;}
     }
 
-    b1.printBoard();
+    b1.print_board();
 
     std::string result_msg;
 


### PR DESCRIPTION
This pull request replaces the integer representation of the board with `std::bitset<9>` and aliases it in `board.h` with
```cpp
typedef std::bitset<9> BoardLayer;
```
This implementation is most likely much more optimised and makes the code more concise. Instead of generating bit masks in the `Board::set_cell()`, `Board::get_free_cells()` and `Board::clear_cell()`, the overloaded `[]` operator can be used to get bits, and methods of `bitset` can be used to set and clear bits.